### PR TITLE
Encode parameters before requesting

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -40,11 +40,8 @@ const headers = {
   "X-Algolia-Application-Id": APPLICATION_ID,
 };
 async function search(query: string) {
-  const payload = {
-    params: new URLSearchParams({ query, facetFilters: '["lang:en-US"]' })
-      .toString(),
-  };
-  const body = enc.encode(JSON.stringify(payload));
+  const params = new URLSearchParams({ query, facetFilters: '["lang:en-US"]' });
+  const body = enc.encode(JSON.stringify({ params: params.toString() }));
   const res = await fetch(SEARCH_URL, { method: "POST", headers, body });
   return await res.json();
 }

--- a/bot.ts
+++ b/bot.ts
@@ -4,7 +4,7 @@ import {
   InlineKeyboard,
   webhookCallback,
 } from "https://deno.land/x/grammy@v1.8.3/mod.ts";
-import { serve } from "https://deno.land/std@0.138.0/http/server.ts";
+import { serve } from "https://deno.land/std@0.141.0/http/server.ts";
 import {
   InlineQueryResultArticle,
   MessageEntity,
@@ -40,7 +40,10 @@ const headers = {
   "X-Algolia-Application-Id": APPLICATION_ID,
 };
 async function search(query: string) {
-  const payload = { params: `query=${query}&facetFilters=["lang:en-US"]` };
+  const payload = {
+    params: new URLSearchParams({ query, facetFilters: '["lang:en-US"]' })
+      .toString(),
+  };
   const body = enc.encode(JSON.stringify(payload));
   const res = await fetch(SEARCH_URL, { method: "POST", headers, body });
   return await res.json();


### PR DESCRIPTION
- This makes the request not break if someone (accidentally) sent an inline query like "&Guide".