### PR TITLE
Remove 'open in new window' appended to external links

### DIFF
--- a/iv-rules.txt
+++ b/iv-rules.txt
@@ -35,6 +35,8 @@ body: //main
 # ... and remove sr content and line number blocks ...
 @remove: //span[has-class("sr-only")]
 @remove: //div[has-class("line-numbers")]
+# ...and remove open in new window icon text
+@remove: //span[has-class("external-link-icon-sr-only")]
 
 # Then, we group code-group-items with their titles:
 # TypeScript > Code, JavasScript > Code


### PR DESCRIPTION
Removes the following 'open in new window' text from links (which are indicated as open in new window links).

**BEFORE**

![image](https://user-images.githubusercontent.com/70066170/171650775-a1349e72-4503-4077-bcae-6293c1f34549.png)

**AFTER**

![image](https://user-images.githubusercontent.com/70066170/171650953-2f28d30e-74c2-41b2-a136-8bef06141fe7.png)
