### PR TITLE
Revert "chore: update IV path structures"

### DIFF
--- a/iv-rules.txt
+++ b/iv-rules.txt
@@ -2,11 +2,11 @@
 ~allowed_origin: "https://grammy.dev"
 
 # Define paths structures
-?path: /((id|es)/)?guide/.*
-?path: /((id|es)/)?advanced/.*
-?path: /((id|es)/)?plugins/.*
-?path: /((id|es)/)?resources/.*
-?path: /((id|es)/)?hosting/.*
+?path: /(zh/)?guide/.*
+?path: /(zh/)?advanced/.*
+?path: /(zh/)?plugins/.*
+?path: /(zh/)?resources/.*
+?path: /(zh/)?hosting/.*
 
 # Title is always the only h1 element
 @replace("#", ""): //h1

--- a/iv-rules.txt
+++ b/iv-rules.txt
@@ -2,11 +2,11 @@
 ~allowed_origin: "https://grammy.dev"
 
 # Define paths structures
-?path: /(zh/)?guide/.*
-?path: /(zh/)?advanced/.*
-?path: /(zh/)?plugins/.*
-?path: /(zh/)?resources/.*
-?path: /(zh/)?hosting/.*
+?path: /((id|es|zh)/)?guide/.*
+?path: /((id|es|zh)/)?advanced/.*
+?path: /((id|es|zh)/)?plugins/.*
+?path: /((id|es|zh)/)?resources/.*
+?path: /((id|es|zh)/)?hosting/.*
 
 # Title is always the only h1 element
 @replace("#", ""): //h1


### PR DESCRIPTION
This reverts commit 9bf02432db0cfa2ba6f69f6b7d57fa7a15547e33.

Reason: https://github.com/grammyjs/website/pull/655#issuecomment-1458162738