### PR TITLE
Add support for locales

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -43,6 +43,15 @@ search query as the link text.
 – Use +search query/+ with a '/' suffix to share the \
 URL itself instead of the page title.
 
+To find results in specific locales, you can prepend '!locale-code' to your search query.
+- For Spanish, use '!es search query'.
+- For Indonesian, use '!id search query'.
+- For Ukrainian, use '!uk search query'.
+- For Chinese, use '!zh search query'.
+
+You may also put them all together like this:
+'!es +search query|this link+'
+
 Join @grammyjs!`,
       { reply_markup: searchKeyboard },
     ),
@@ -57,7 +66,7 @@ bot.drop((ctx) => ctx.msg?.via_bot?.id === ctx.me.id)
 
 bot.on("inline_query", async (ctx) => {
   const { query, offset } = ctx.inlineQuery;
-  const { currentQuery, texts, completedQueries } = parse(query);
+  const { currentQuery, texts, completedQueries, lang } = parse(query);
   const links = await Promise.all(
     completedQueries.map(async (query) => ({
       query,
@@ -73,8 +82,8 @@ bot.on("inline_query", async (ctx) => {
     // pending current query
     const off = parseInt(offset, 10);
     const hits = isNaN(off)
-      ? await search(currentQuery.query)
-      : await search(currentQuery.query, { offset: off });
+      ? await search(currentQuery.query, lang)
+      : await search(currentQuery.query, lang, { offset: off });
     nextOffset += hits.length;
     if (texts.length === 0) {
       // no rendering

--- a/parse.ts
+++ b/parse.ts
@@ -5,6 +5,7 @@ export interface ParseResult {
   completedQueries: LabeledQuery[];
   /** Interspersed text fragments */
   texts: string[];
+  lang: string;
 }
 export interface LabeledQuery {
   query: string;
@@ -12,9 +13,33 @@ export interface LabeledQuery {
 }
 
 export function parse(query: string) {
+  let facetFilters = "lang:en-US";
+  const re = /^!(en|es|id|uk|zh)(?:\s)(.*)$/i;
+  const match = query.match(re);
+
+  if (match) {
+    const [, lang, _query] = match;
+    switch (lang.toLowerCase()) {
+      case "es":
+        facetFilters = "lang:es-ES";
+        break;
+      case "id":
+        facetFilters = "lang:id";
+        break;
+      case "uk":
+        facetFilters = "lang:uk-UA";
+        break;
+      case "zh":
+        facetFilters = "lang:zh";
+        break;
+    }
+    query = _query;
+  }
+
   const result: ParseResult = {
     completedQueries: [],
     texts: [],
+    lang: facetFilters,
   };
   const parts = query.split("+");
   const len = parts.length;

--- a/search.ts
+++ b/search.ts
@@ -26,6 +26,7 @@ export async function searchOne(query: string) {
 }
 export async function search(
   query: string,
+  lang: string,
   options?: SearchPaginationOptions,
 ): Promise<Hit[]> {
   const page = options === undefined ? undefined : {
@@ -35,7 +36,7 @@ export async function search(
   const params = new URLSearchParams({
     query,
     ...page,
-    facetFilters: '["lang:en-US"]',
+    facetFilters: `["${lang}"]`,
   });
   const body = enc.encode(JSON.stringify({ params: params.toString() }));
   const res = await fetch(SEARCH_URL, { method: "POST", headers, body });


### PR DESCRIPTION
You can prepend `!<locale-code>` to the search query. For example, `!id long polling` or `!zh +webhook/+`. If no locale-code is specified, English will be used by default.